### PR TITLE
make sure node.content is always an ArrayBuffer

### DIFF
--- a/src/mailreader-parser.js
+++ b/src/mailreader-parser.js
@@ -247,7 +247,7 @@
 
         // normalize the contents
         node.raw = node.raw || '';
-        node.content = node.content || '';
+        node.content = node.content || new Uint8Array(0);
 
         // optional
         if (node.headers['content-id']) {


### PR DESCRIPTION
`node.content` is later fed to `TextDecoder#decode`. While the emailjs-stringencoding shim does accept empty strings, the [native browser implementation](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/decode) always wants an ArrayBuffer and therefore chokes on empty strings.

This patch makes it possible to substitute the native browser TextDecoder implementation for the emailjs shim in supported browsers.
